### PR TITLE
feat: restyle UI with Rarible-inspired theme

### DIFF
--- a/pokerboots-mvp/src/components/ActionBar.tsx
+++ b/pokerboots-mvp/src/components/ActionBar.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default function ActionBar({ street, ...actions }: Props) {
   return (
-    <div className="flex gap-4">
+    <div className="flex gap-4 card p-2 rounded-full">
       {street === 'preflop' && <button onClick={actions.onFlop}  className="btn">Deal Flop</button>}
       {street === 'flop'     && <button onClick={actions.onTurn} className="btn">Deal Turn</button>}
       {street === 'turn'     && <button onClick={actions.onRiver}className="btn">Deal River</button>}

--- a/pokerboots-mvp/src/components/Card.tsx
+++ b/pokerboots-mvp/src/components/Card.tsx
@@ -51,5 +51,7 @@ export default function Card({ card, hidden, size = 'md' }: Props) {
       ? cardStarknet
       : faceSvgs[faceKey(card)] ?? cardStarknet; // fallback to back if missing
 
-  return <img src={src} className={className} draggable={false} />;
+  const style = !hidden && card ? { border: '2px solid var(--brand-accent)' } : undefined;
+
+  return <img src={src} className={className} style={style} draggable={false} />;
 }

--- a/pokerboots-mvp/src/components/HeroSection.tsx
+++ b/pokerboots-mvp/src/components/HeroSection.tsx
@@ -7,22 +7,24 @@ import appMockup from '../assets/app-mockup.png';
  */
 export default function HeroSection() {
   return (
-    <section id="home" className="relative flex flex-col justify-center h-[100vh] px-6 md:px-12 overflow-hidden">
+    <section
+      id="home"
+      className="relative flex flex-col justify-center items-center h-screen px-6 md:px-12 overflow-hidden text-center"
+    >
       {/* decorative angle */}
-      <div className="absolute inset-0 bg-gradient-to-tr from-transparent via-blue-600/20 to-indigo-800/10 [clip-path:polygon(0_0,100%_0,100%_75%,0_100%)] pointer-events-none" />
+      <div className="absolute inset-0 bg-gradient-to-tr from-[var(--brand-accent)]/20 via-purple-600/10 to-indigo-700/10 [clip-path:polygon(0_0,100%_0,100%_75%,0_100%)] pointer-events-none" />
 
       {/* content wrapper */}
       <div className="relative z-10 max-w-4xl w-full mx-auto">
         {/* headline */}
-        <h1 className="font-extrabold text-4xl md:text-4xl leading-tight uppercase tracking-wider text-left">
-          <span className="block text-yellow-400">POKER ON STARKNET</span>
-          <span className="block text-white-400">SPIN UP YOUR TOURNAMENT</span>
-          <span className="block text-white-400">WITH NFT SALE</span>
-
+        <h1 className="font-extrabold text-4xl md:text-5xl leading-tight uppercase tracking-wider">
+          <span className="block text-[var(--brand-accent)]">POKER ON STARKNET</span>
+          <span className="block text-white">SPIN UP YOUR TOURNAMENT</span>
+          <span className="block text-white">WITH NFT SALE</span>
         </h1>
 
         {/* subline */}
-        <p className="mt-4 text-slate-300 text-lg md:text-xl text-left">
+        <p className="mt-4 text-slate-300 text-lg md:text-xl">
           Mint tickets → Prize pool auto‑escrows → Smart‑contract payouts.
         </p>
 
@@ -34,11 +36,14 @@ export default function HeroSection() {
         </ul>
 
         {/* CTA */}
-        <div className="mt-10 flex gap-4" >
-          <a href="/#mint" className="px-6 py-3 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow hover:bg-yellow-300 transition-colors">
+        <div className="mt-10 flex gap-4 justify-center">
+          <a href="/#mint" className="btn">
             BUY NFT
           </a>
-          <a href="/play" className="px-6 py-3 bg-transparent border border-yellow-400 text-yellow-400 font-semibold rounded-lg hover:bg-yellow-400 hover:text-[#0c1a3a] transition-colors">
+          <a
+            href="/play"
+            className="btn" style={{ background: 'transparent', color: 'var(--brand-accent)', border: '2px solid var(--brand-accent)' }}
+          >
             PLAY NOW
           </a>
         </div>

--- a/pokerboots-mvp/src/components/Menu.tsx
+++ b/pokerboots-mvp/src/components/Menu.tsx
@@ -9,33 +9,40 @@ import { useState } from 'react';
 export default function FloatingMenu() {
   const [open, setOpen] = useState(false);
   const links = [
-    { label: 'Home',       href: '/#home' },
-    { label: 'Mint NFT',   href: '/#mint' },
+    { label: 'Home', href: '/#home' },
+    { label: 'Mint NFT', href: '/#mint' },
     { label: 'Tournaments', href: '/#boards' },
-    { label: 'Follow Us',  href: '/#stay' }
+    { label: 'Follow Us', href: '/#stay' }
   ];
 
   return (
-    <nav className="fixed top-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-4 bg-black/50 backdrop-blur-md px-6 py-2 rounded-full border border-white/10 shadow-lg">
+    <nav className="fixed top-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-6 card px-8 py-3 rounded-full">
+      <span className="font-extrabold text-lg text-[var(--brand-accent)]">PokerBoots</span>
+
       {/* mobile burger */}
-      <button onClick={() => setOpen(!open)} className="md:hidden w-8 h-8 flex flex-col justify-between">
-        <span className="block w-full h-[2px] bg-yellow-400" />
-        <span className="block w-full h-[2px] bg-yellow-400" />
-        <span className="block w-full h-[2px] bg-yellow-400" />
+      <button
+        onClick={() => setOpen(!open)}
+        className="md:hidden w-8 h-8 flex flex-col justify-between"
+      >
+        <span className="block w-full h-[2px] bg-[var(--brand-accent)]" />
+        <span className="block w-full h-[2px] bg-[var(--brand-accent)]" />
+        <span className="block w-full h-[2px] bg-[var(--brand-accent)]" />
       </button>
 
       {/* links */}
-      <ul className={`md:flex md:gap-6 ${open ? 'flex flex-col gap-4 mt-4' : 'hidden'} md:mt-0`}>
+      <ul
+        className={`md:flex md:gap-6 ${open ? 'flex flex-col gap-4 mt-4' : 'hidden'} md:mt-0`}
+      >
         {links.map(l => (
-        <li key={l.href}>
+          <li key={l.href}>
             <a
-            href={l.href}
-            className="text-yellow-400 hover:text-white font-semibold transition-colors"
-            onClick={() => setOpen(false)}
+              href={l.href}
+              className="text-white font-semibold hover:text-[var(--brand-accent)] transition-colors"
+              onClick={() => setOpen(false)}
             >
-            {l.label}
+              {l.label}
             </a>
-        </li>
+          </li>
         ))}
       </ul>
     </nav>

--- a/pokerboots-mvp/src/components/NFTSaleSection.tsx
+++ b/pokerboots-mvp/src/components/NFTSaleSection.tsx
@@ -29,8 +29,8 @@ export default function NftSaleSection() {
 
   /* ---------------------- JSX ---------------------- */
   return (
-    <section id="mint" className="relative py-24 px-6 md:px-12 bg-[#0a1a38] text-white">
-      <h2 className="text-3xl md:text-4xl font-extrabold text-yellow-300 text-center mb-12">Spin Up Tournament with NFTs</h2>
+    <section id="mint" className="relative py-24 px-6 md:px-12 bg-gradient-to-br from-[#141414] via-[#1b1b1b] to-[#232323] text-white">
+      <h2 className="text-3xl md:text-4xl font-extrabold text-[var(--brand-accent)] text-center mb-12">Spin Up Tournament with NFTs</h2>
       <div className="max-w-6xl mx-auto flex flex-col md:flex-row gap-12">
         {/* NFT preview */}
         <div className="flex-1 flex justify-center">
@@ -38,7 +38,7 @@ export default function NftSaleSection() {
         </div>
         {/* Configurator */}
         <div className="flex-1">
-          <div className="bg-white/5 backdrop-blur-md p-8 rounded-xl border border-yellow-400/30 shadow-lg space-y-5">
+          <div className="card p-8 space-y-5">
             <Field label="Title" name="name" value={form.name} onChange={handleChange} />
             <Field label="Creator" name="creator" value={form.creator} onChange={handleChange} />
             <Field label="Description" name="description" value={form.description} onChange={handleChange} textarea />
@@ -68,7 +68,7 @@ export default function NftSaleSection() {
               </select>
             </label>
 
-            <button className="w-full mt-6 py-3 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg hover:bg-yellow-300 transition-colors">Launch (TBD)</button>
+            <button className="w-full mt-6 btn">Launch (TBD)</button>
           </div>
         </div>
       </div>

--- a/pokerboots-mvp/src/components/PlayerSeat.tsx
+++ b/pokerboots-mvp/src/components/PlayerSeat.tsx
@@ -21,14 +21,14 @@ export default function PlayerSeat({
   return (
     <div
       className={clsx(
-        'relative flex flex-col items-center gap-1',
+        'relative flex flex-col items-center gap-1 card p-2 rounded-xl',
         player.folded && 'opacity-60',
-        isActive && 'ring-4 ring-amber-300 rounded-lg'
+        isActive && 'ring-4 ring-[var(--brand-accent)]'
       )}
     >
       {/* dealer button */}
       {isDealer && (
-        <span className="absolute -top-3 -right-3 w-6 h-6 rounded-full bg-yellow-400 text-black text-xs font-bold flex items-center justify-center">
+        <span className="absolute -top-3 -right-3 w-6 h-6 rounded-full bg-[var(--brand-accent)] text-black text-xs font-bold flex items-center justify-center">
           D
         </span>
       )}

--- a/pokerboots-mvp/src/components/StayTunedSection.tsx
+++ b/pokerboots-mvp/src/components/StayTunedSection.tsx
@@ -6,14 +6,14 @@ import { FaTwitter, FaInstagram, FaDiscord } from 'react-icons/fa';
  */
 export default function StayTunedSection() {
   return (
-    <section id="stay" className="relative bg-[#0e244f] py-24 px-6 md:px-12 text-center overflow-hidden">
+    <section id="stay" className="relative bg-gradient-to-br from-[#141414] via-[#1b1b1b] to-[#232323] py-24 px-6 md:px-12 text-center overflow-hidden">
       {/* diagonal top separator */}
       <div className="absolute -top-16 left-0 w-full h-16 bg-gradient-to-br from-transparent via-blue-900/60 to-blue-950/80 skew-y-[-3deg] origin-top" />
 
       {/* subtle radial glow */}
       <div className="absolute inset-0 bg-gradient-to-br from-blue-800/10 via-indigo-600/10 to-purple-700/10 rounded-[40%] blur-[180px] -z-10" />
 
-      <h2 className="text-3xl md:text-4xl font-extrabold tracking-wide text-yellow-300">Stay Tuned</h2>
+      <h2 className="text-3xl md:text-4xl font-extrabold tracking-wide text-[var(--brand-accent)]">Stay Tuned</h2>
       <p className="max-w-xl mx-auto mt-4 text-slate-300">
         Follow us for launch announcements, tournament drops, and behind‑the‑scenes updates.
       </p>

--- a/pokerboots-mvp/src/components/Table.tsx
+++ b/pokerboots-mvp/src/components/Table.tsx
@@ -90,7 +90,7 @@ export default function Table() {
       {/* poker-table oval */}
       <div
         className="
-          relative rounded-full border-8 border-black bg-blue-900
+          relative rounded-full border-8 border-[var(--brand-accent)] bg-gradient-to-br from-[#1e1e1e] to-[#0e0e0e]
           shadow-[0_0_40px_rgba(0,0,0,0.6)]
           w-[680px] h-[420px]
         "

--- a/pokerboots-mvp/src/components/TournamentBoards.tsx
+++ b/pokerboots-mvp/src/components/TournamentBoards.tsx
@@ -1,20 +1,20 @@
 import { useState } from 'react';
 
 /**
- * TournamentBoards – shows Top Sales / Most Popular / Upcoming with live bankroll math.
+ * TournamentBoards – shows Top Sales / Most Popular / Upcoming with live bankroll math.
  */
-export default function TournamentBoards() {
-  type Row = {
-    Name: string;
-    Game: string;
-    Ticket: number; // price in USD
-    Sold: number;   // how many minted
-    Total: number;  // max supply
-    Bank: number;   // auto‑computed prize pool (sold × ticket × 0.8)
-    Date: string;
-    Creator: string;
-  };
+type Row = {
+  Name: string;
+  Game: string;
+  Ticket: number; // price in USD
+  Sold: number;   // how many minted
+  Total: number;  // max supply
+  Bank: number;   // auto-computed prize pool (sold × ticket × 0.8)
+  Date: string;
+  Creator: string;
+};
 
+export default function TournamentBoards() {
   const columns: (keyof Row & string)[] = [
     'Name',
     'Game',
@@ -39,8 +39,8 @@ export default function TournamentBoards() {
   const rows = Array.from({ length: 10 }, (_, i) => makeRow(1000 - i * 75));
 
   return (
-    <section id="boards" className="relative py-24 px-6 md:px-12 bg-[#081224] text-white">
-      <h2 className="text-3xl md:text-4xl font-extrabold text-yellow-300 text-center mb-12">Explore</h2>
+    <section id="boards" className="relative py-24 px-6 md:px-12 bg-gradient-to-br from-[#141414] via-[#1b1b1b] to-[#232323] text-white">
+      <h2 className="text-3xl md:text-4xl font-extrabold text-[var(--brand-accent)] text-center mb-12">Explore</h2>
       <div className="flex flex-col gap-10 max-w-6xl mx-auto">
         <InsightBoard title="Top Sales" columns={columns} rows={rows} />
         <InsightBoard title="Most Popular" columns={columns} rows={rows} />
@@ -51,12 +51,12 @@ export default function TournamentBoards() {
 }
 
 /* ────────── Generic Board ────────── */
-interface BoardProps<T extends Record<string, any>> {
+interface BoardProps {
   title: string;
-  columns: (keyof T & string)[];
-  rows: T[];
+  columns: (keyof Row & string)[];
+  rows: Row[];
 }
-function InsightBoard<T extends Record<string, any>>({ title, columns, rows }: BoardProps<T>) {
+function InsightBoard({ title, columns, rows }: BoardProps) {
   const [filter, setFilter] = useState('');
   const lc = filter.toLowerCase();
   const filtered = rows.filter(r =>
@@ -64,7 +64,7 @@ function InsightBoard<T extends Record<string, any>>({ title, columns, rows }: B
   );
 
   return (
-    <div className="bg-white/5 backdrop-blur-md p-6 rounded-xl border border-white/10 shadow-lg">
+    <div className="card p-6">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
         <h3 className="text-xl font-semibold text-yellow-300">{title}</h3>
         <input

--- a/pokerboots-mvp/src/index.css
+++ b/pokerboots-mvp/src/index.css
@@ -1,0 +1,37 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap');
+
+:root {
+  --brand-accent: #ffdc00;
+  --brand-accent-secondary: #ff8e00;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: radial-gradient(circle at top left, #131313 0%, #0d0d0d 100%);
+  color: #ffffff;
+  min-height: 100vh;
+}
+
+.btn {
+  background: linear-gradient(90deg, var(--brand-accent), var(--brand-accent-secondary));
+  color: #000000;
+  padding: 0.5rem 1.25rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  box-shadow: 0 4px 14px rgba(255, 220, 0, 0.5);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(255, 220, 0, 0.7);
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+

--- a/pokerboots-mvp/src/pages/HomePage.tsx
+++ b/pokerboots-mvp/src/pages/HomePage.tsx
@@ -12,7 +12,7 @@ import Menu from '../components/Menu';
  */
 export default function HomePage() {
   return (
-    <div className="min-h-screen text-white bg-gradient-to-b from-[#02040b] via-[#0c1a3a] to-[#102047] overflow-x-hidden">
+    <div className="min-h-screen text-white bg-gradient-to-b from-[#0d0d0d] via-[#1b1b1b] to-[#232323] overflow-x-hidden">
       <Menu />
       <HeroSection />
       <NftSaleSection />

--- a/pokerboots-mvp/src/pages/HomeTables.tsx
+++ b/pokerboots-mvp/src/pages/HomeTables.tsx
@@ -15,12 +15,12 @@ export default function HomeTables() {
 
 
   return (
-    <main className="min-h-screen flex flex-col items-center bg-gradient-to-br from-green-900 to-green-700 text-white">
+    <main className="min-h-screen flex flex-col items-center bg-gradient-to-br from-[#0d0d0d] via-[#1b1b1b] to-[#232323] text-white">
       <header className="relative w-full max-w-6xl flex items-center justify-between mt-6 mb-4 px-4">
         <h1 className="text-4xl font-bold">PokerBoots × Starknet</h1>
 
         <button
-          className="absolute left-1/2 -translate-x-1/2 px-4 py-2 rounded bg-blue-900 hover:bg-red-500 font-semibold"
+          className="absolute left-1/2 -translate-x-1/2 btn"
           onClick={() => alert('join logic TBD')}
         >
           Join Table


### PR DESCRIPTION
## Summary
- add global Rarible-inspired theme styles for buttons and cards
- restyle navigation, hero, and tournament sections with dark gradients and accent colors
- apply unified styling across gameplay components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689203a8fa308324bafda0c20897a02c