### PR TITLE
docs: add contract overviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # Onchain Poker with Starknet
+
+Pokerboots is an experiment in running poker tournaments entirely on
+Starknet. The `pokerboots-contracts` package contains the Cairo smart
+contracts that manage tournaments, tickets and payouts.
+
+## Contract Summary
+
+- **Bank.cairo** – tracks player deposits, issues refunds and pays out
+  winners using an ERC20 token.
+- **CreatorEscrow.cairo** – holds the creator’s share of ticket sales
+  until withdrawal.
+- **DeckShuffler.cairo** – produces a shuffled deck through a
+  commit‑reveal process and VRF randomness.
+- **HandEvaluator.cairo** – evaluates seven-card hands to determine
+  poker rankings.
+- **Lobby.cairo** – registers tournaments and links their auction,
+  ticket and escrow contracts.
+- **NFTAuction.cairo** – sells tournament tickets, splits fees and
+  mints the corresponding NFT.
+- **NFTTicket.cairo** – lightweight NFT representing tournament entry
+  with delegation features.
+- **ProtocolTreasury.cairo** – vault for protocol fees that the owner
+  can withdraw.
+- **TableState.cairo** – coordinates seating, game phases and payouts
+  at a poker table.
+
+See [pokerboots-contracts/README.md](pokerboots-contracts/README.md) for
+build instructions and additional details.
+

--- a/pokerboots-contracts/README.md
+++ b/pokerboots-contracts/README.md
@@ -1,18 +1,44 @@
 
-# How to use DeckShuffler
+## Contract Summary
+
+This package contains Cairo contracts that power the onchain poker
+application. Below is a high-level overview of each module.
+
+- **Accounts.cairo** – placeholder for future account utilities.
+- **Bank.cairo** – records player deposits, issues refunds and executes
+  payouts in an ERC20 token.
+- **CreatorEscrow.cairo** – stores the creator's share of ticket sales
+  until it is withdrawn.
+- **DeckShuffler.cairo** – generates a shuffled deck via a
+  commit‑reveal scheme using VRF randomness.
+- **HandEvaluator.cairo** – ranks seven-card poker hands with lookup
+  tables.
+- **Lobby.cairo** – tracks tournaments and their associated auction,
+  ticket, and escrow contracts.
+- **NFTAuction.cairo** – sells tickets, splits fees, mints NFTs and
+  forwards the pool to the bank.
+- **NFTTicket.cairo** – lightweight NFT representing tournament entry,
+  supporting batch transfers and user assignments.
+- **ProtocolTreasury.cairo** – holds protocol fees and allows the owner
+  to withdraw balances.
+- **TableState.cairo** – coordinates seating, game phases and interacts
+  with the shuffler, evaluator and bank.
+
+## How to use DeckShuffler
+
 Files: DeckShuffler.cairo, deck_rng.py, test_deck_shuffler.py
 
-# 1. on-chain part
+### 1. on-chain part
 rustup override set stable && rustup update
 cargo install --locked scarb starknet-foundry
 scarb build   # compiles DeckShuffler.cairo
 
-# 2. local testnet & unit tests
+### 2. local testnet & unit tests
 pip install pytest starknet-devnet==0.13.5 starknet-foundry
 pytest test_deck_shuffler.py          # contract integration
 python deck_rng.py -v                 # RNG χ² + reproducibility
 
-# 3. deploy
+### 3. deploy
 starkli declare --contract target/release/DeckShuffler.sierra.json
 starkli deploy --class_hash <hash> --network sepolia
 


### PR DESCRIPTION
## Summary
- add contract summaries and pointers in root documentation
- document each Cairo contract in `pokerboots-contracts`

## Testing
- `cargo install --locked scarb` *(fails: type annotations needed for `Box<_>` in time crate)*

------
https://chatgpt.com/codex/tasks/task_e_68981c3b055c8324a6c43239c598b13a